### PR TITLE
Add an optional section navigation

### DIFF
--- a/docs/ercisbeamerdocs.tex
+++ b/docs/ercisbeamerdocs.tex
@@ -171,8 +171,13 @@ lekse@lugmedia.de}
 
 \subsection{\en{Frame layouts}\de{Folienlayouts}}
 
+
 \en{The template extends the \texttt{frame} environment of the beamer package with additional options to influence the layout of a frame. These options are summarized in table~\ref{tab:features-framelayouts} can be combined with each other.}
 \de{Die Vorlage erweitert die \texttt{frame} Umgebung des beamer Pakets um zusätzliche Optionen, die das Layout einer Folie beeinflussen. Diese zusätzlich verfügbaren Optionen sind in Tabelle~\ref{tab:features-framelayouts} zusammengefasst und können beliebig miteinander kombiniert werden.}
+
+\en{Optionally, frames will display a single line containing a (hyperlinked) list of section titles at the very top. This is enabled by passing the \textt{navigation} option to the \varstylename package (e.\,g., \texttt{\textbackslash usepackage[navigation]\{\varstylename\}}. This line can then be suppressed for individual frames by adding the \textt{nonav} option (see table~\ref{tab:features-framelayouts}).}
+\de{Inhaltsfolien können optional um eine einzeilige Abschnitts-Navigation ergänzt werden. Diese wird angezeigt, indem dem \varstylename-Paket die \textt{navigation}-Option übergeben wird (z.\,B. \texttt{\textbackslash usepackage[navigation]\{\varstylename\}}). Diese Navigation kann dann für einzelne Folien wieder unterdrückt werden, indem ihnen die \textt{nonav}-Option gegeben wird (s. Tabelle~\ref{tab:features-framelayouts}).}
+
 \begin{table}[H]%
   \begin{center}%
     \renewcommand{\arraystretch}{1.25}
@@ -184,6 +189,7 @@ lekse@lugmedia.de}
       \texttt{notitle} & \en{Hides the title in the headline}\de{Unterdrückt den Titel in der Kopfzeile} \tabularnewline
       \texttt{nosubtitle} & \en{Hides the subtitle in the headline}\de{Unterdrückt den Untertitel in der Kopfzeile} \tabularnewline
       \texttt{nofootline} & \en{Hides the footline}\de{Unterdrückt die Fußzeile} \tabularnewline
+      \texttt{nonav} & \en{Hides the section navigation}\de{Unterdrückt das Inhaltsverzeichnis} \tabularnewline
       \hline
     \end{tabular}
     \caption{\en{Additional frame layouts}\de{Zusätzliche Folienlayouts}\label{tab:features-framelayouts}}%

--- a/src/custom-styles.tex
+++ b/src/custom-styles.tex
@@ -34,3 +34,8 @@
 
 \setbeamerfont{final page contact}{size*={14}{0}, series*={b}}
 \setbeamercolor*{final page contact}{fg=ercisred}
+
+\makeatletter
+\provideboolean{ercisbeamer@showsectionnav}
+\setboolean{ercisbeamer@showsectionnav}{false}
+\makeatother

--- a/src/frame-options.tex
+++ b/src/frame-options.tex
@@ -5,6 +5,11 @@
   \beamer@renderheadlinelogofalse%
 }
 
+% Define option for hiding the mini navbar in the headline
+\define@key{beamerframe}{nonav}[]{%
+  \beamer@renderheadlinenavfalse%
+}
+
 % Define option for hiding the title in the headline
 \define@key{beamerframe}{notitle}[]{%
   \beamer@renderheadlinetitlefalse%
@@ -22,6 +27,7 @@
 
 % Define condition macros
 \newif\ifbeamer@renderheadlinelogo
+\newif\ifbeamer@renderheadlinenav
 \newif\ifbeamer@renderheadlinetitle
 \newif\ifbeamer@renderheadlinesubtitle
 \newif\ifbeamer@renderfootline
@@ -31,6 +37,11 @@
 \beamer@renderheadlinetitletrue
 \beamer@renderheadlinesubtitletrue
 \beamer@renderfootlinetrue
+\ifthenelse{\boolean{ercisbeamer@showsectionnav}}{%
+  \beamer@renderheadlinenavtrue%
+}{%
+  \beamer@renderheadlinenavfalse%
+}
 
 % Patch beamer frame macro to apply default value for each frame
 \let\ercisbeamer@options@beamer@@@@frame\beamer@@@@frame
@@ -39,6 +50,11 @@
   \beamer@renderheadlinetitletrue%
   \beamer@renderheadlinesubtitletrue%
   \beamer@renderfootlinetrue%
+  \ifthenelse{\boolean{ercisbeamer@showsectionnav}}{%
+    \beamer@renderheadlinenavtrue%
+  }{%
+    \beamer@renderheadlinenavfalse%
+  }%
   \ercisbeamer@options@beamer@@@@frame<#1>[#2]%
 }
 

--- a/src/options.tex
+++ b/src/options.tex
@@ -32,6 +32,12 @@
   \nocacheAll%
 }
 
+\DeclareOption{navigation}{
+  \makeatletter
+  \setboolean{ercisbeamer@showsectionnav}{true}
+  \makeatother
+}
+
 % Process all defined options
 \ProcessOptions\relax
 

--- a/src/template-headline.tex
+++ b/src/template-headline.tex
@@ -22,6 +22,13 @@
           \beamer@cacheUse{headline-ercis-logo}{\headlineErcisLogo}%
         };
       \fi
+
+      % mininav
+      \ifbeamer@renderheadlinenav
+        \node[fill,color=white,anchor=north west, no sep, minimum width=\textwidth-\leftTextMargin-\rightTextMargin] at (\leftTextMargin, \headlineHeight-1mm) {%
+          \insertsectionnavigationhorizontal{\linewidth}{}{}%
+        };
+      \fi
     \end{tikzpicture}%
   }%
 }


### PR DESCRIPTION
This change adds two options that control the presence of a section navigation (by default it is turned off):

- global package option: `navigation` (turns it on)
- frame option: `nonav` (turns it off for the frame)

![section navigation](https://user-images.githubusercontent.com/432117/93187846-87691580-f740-11ea-804f-bc228518e0bf.png)
